### PR TITLE
Fix inconsistent behavior

### DIFF
--- a/stockcount/main/routes.py
+++ b/stockcount/main/routes.py
@@ -58,10 +58,22 @@ def report():
     today = date_time.trans_date.strftime("%Y-%m-%d")
     today = datetime.strptime(today, "%Y-%m-%d")
     yesterday = today - timedelta(days=1)    
-
-    # start timer
+    
+    # Get the date of the 2nd most recent count.
+    prev_date = (
+        db.session.query(InvCount.trans_date)
+        .filter(
+            InvCount.store_id == session["store"],
+            InvCount.trans_date < today,
+        )
+        .order_by(InvCount.trans_date.desc())
+        .first()
+    )
+    prev_date = prev_date[0]
+    prev_date = prev_date.strftime('%Y-%m-%d')
+    
     start = time.time()
-    ordered_counts = getVariance(session["store"], today)
+    ordered_counts = getVariance(session["store"], today, prev_date)
     sirloin_purchases = getSirloinPurchases(session["store"], yesterday, today)
     # ic(ordered_counts)
     end = time.time()
@@ -73,7 +85,6 @@ def report():
         title="Variance-Daily",
         **locals(),
     )
-
 
 @blueprint.route("/report/<product>/details", methods=["GET", "POST"])
 @login_required

--- a/stockcount/main/utils.py
+++ b/stockcount/main/utils.py
@@ -137,7 +137,7 @@ def getSirloinPurchases(store_id, start_date, end_date):
     return results
 
 
-def getVariance(store_id, date):
+def getVariance(store_id, date, prev_date):
     query = """
     WITH current_day AS (
         SELECT item_id, item_name, count_total
@@ -187,7 +187,7 @@ def getVariance(store_id, date):
     params = {
         'store_id': store_id,
         'trans_date': date,
-        'previous_date': date - timedelta(days=1),  # Provide the correct date for previous_day query
+        'previous_date': prev_date,  # Provide the correct date for previous_day query
         'sales_date': date,
         'purchase_date': date,
         'waste_date': date


### PR DESCRIPTION
There was an error with the /report page where it was doing a lazy check for the previous count. It was just checking for the counts on the day before the current count which caused some restaurants to have a count of 0.
This behavior was not consistent with /report/detail which does a more thorough search so now if they skip days the count will not default to zero but will pull their most recent previous count.

Example:
Original behavior
Sept-9 Count = 97 prevCount = 0
Sept-8 --No Entry--
Sept-7 Count = 60

New behavior
Sept-9 Count = 97 prevCount = 60
Sept-8 --No Entry--
Sept-7 Count = 60

